### PR TITLE
Added change suggested by David Taylor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ include_directories(include ${catkin_INCLUDE_DIRS}
 add_executable(apriltags_intrude_detector src/apriltags_intrude_detector.cpp
                                           src/apriltags_intrude_detector_demo.cpp
               )
+add_dependencies(apriltags_intrude_detector apriltags_intrude_detector_gencpp)
 target_link_libraries(apriltags_intrude_detector ${catkin_LIBRARIES} 
                                                  ${OpenCV_LIBRARIES}
                                                  ${CGAL_LIBRARIES}


### PR DESCRIPTION
This change is supposed to help the project build when Catkin uses multiple threads. According to David one thread would try to use files that another thread had not yet built.

It didn't seem to work for me (though it seems like it should), instead I had to run 'catkin_make -j 1' to get it to run with only one thread. I said as much in the online setup doc here: https://docs.google.com/document/d/1w430S3PFG9I60u9MR6WkINqOxHSk6rquQSX6lXdq0LM/edit?ts=57154cdb (see page 3)
